### PR TITLE
Initial implementation of the network context controller

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,11 +5,9 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - compute.datumapis.com
+  - compute.cnrm.cloud.google.com
   resources:
-  - networkcontexts
-  - workloaddeployments
-  - workloads
+  - computenetworks
   verbs:
   - create
   - delete
@@ -19,19 +17,29 @@ rules:
   - update
   - watch
 - apiGroups:
+  - compute.cnrm.cloud.google.com
+  resources:
+  - computenetworks/status
+  verbs:
+  - get
+- apiGroups:
+  - compute.datumapis.com
+  resources:
+  - networkcontexts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - compute.datumapis.com
   resources:
   - networkcontexts/finalizers
-  - workloaddeployments/finalizers
-  - workloads/finalizers
   verbs:
   - update
 - apiGroups:
   - compute.datumapis.com
   resources:
   - networkcontexts/status
-  - workloaddeployments/status
-  - workloads/status
   verbs:
   - get
   - patch

--- a/internal/controller/annotations.go
+++ b/internal/controller/annotations.go
@@ -1,0 +1,5 @@
+package controller
+
+const (
+	GCPProjectAnnotation = "cnrm.cloud.google.com/project-id"
+)

--- a/internal/controller/k8sconfigconnector/conditions.go
+++ b/internal/controller/k8sconfigconnector/conditions.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package k8sconfigconnector
+
+import (
+	gcpcomputev1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// IsStatusConditionTrue returns true when the conditionType is present and set to `gcpcomputev1alpha1.ConditionTrue`
+func IsStatusConditionTrue(conditions []gcpcomputev1alpha1.Condition, conditionType string) bool {
+	return IsStatusConditionPresentAndEqual(conditions, conditionType, corev1.ConditionTrue)
+}
+
+// IsStatusConditionPresentAndEqual returns true when conditionType is present and equal to status.
+func IsStatusConditionPresentAndEqual(conditions []gcpcomputev1alpha1.Condition, conditionType string, status corev1.ConditionStatus) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status == status
+		}
+	}
+	return false
+}

--- a/internal/controller/networkcontext_controller.go
+++ b/internal/controller/networkcontext_controller.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	kcccomputev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/compute/v1beta1"
+	kcccomputev1alpha1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
+	"google.golang.org/protobuf/proto"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"go.datum.net/infra-provider-gcp/internal/controller/k8sconfigconnector"
+
+	networkingv1alpha "go.datum.net/network-services-operator/api/v1alpha"
+)
+
+// NetworkContextReconciler reconciles a NetworkContext and ensures that a GCP
+// ComputeNetwork is created to represent the context within GCP.
+type NetworkContextReconciler struct {
+	client.Client
+	Scheme     *runtime.Scheme
+	GCPProject string
+}
+
+// +kubebuilder:rbac:groups=compute.datumapis.com,resources=networkcontexts,verbs=get;list;watch
+// +kubebuilder:rbac:groups=compute.datumapis.com,resources=networkcontexts/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=compute.datumapis.com,resources=networkcontexts/finalizers,verbs=update
+
+// +kubebuilder:rbac:groups=compute.cnrm.cloud.google.com,resources=computenetworks,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=compute.cnrm.cloud.google.com,resources=computenetworks/status,verbs=get
+
+func (r *NetworkContextReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, err error) {
+	logger := log.FromContext(ctx)
+
+	var networkContext networkingv1alpha.NetworkContext
+	if err := r.Client.Get(ctx, req.NamespacedName, &networkContext); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if !networkContext.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("reconciling network context")
+	defer logger.Info("reconcile complete")
+
+	readyCondition := metav1.Condition{
+		Type:               networkingv1alpha.NetworkBindingReady,
+		Status:             metav1.ConditionFalse,
+		Reason:             "Unknown",
+		ObservedGeneration: networkContext.Generation,
+		Message:            "Unknown state",
+	}
+
+	defer func() {
+		if err != nil {
+			// Don't update the status if errors are encountered
+			return
+		}
+		statusChanged := apimeta.SetStatusCondition(&networkContext.Status.Conditions, readyCondition)
+
+		if statusChanged {
+			err = r.Client.Status().Update(ctx, &networkContext)
+		}
+	}()
+
+	var network networkingv1alpha.Network
+	networkObjectKey := client.ObjectKey{
+		Namespace: networkContext.Namespace,
+		Name:      networkContext.Spec.Network.Name,
+	}
+	if err := r.Client.Get(ctx, networkObjectKey, &network); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed fetching network: %w", err)
+	}
+
+	kccNetworkName := fmt.Sprintf("network-%s", networkContext.UID)
+
+	var kccNetwork kcccomputev1beta1.ComputeNetwork
+	kccNetworkObjectKey := client.ObjectKey{
+		Namespace: networkContext.Namespace,
+		Name:      kccNetworkName,
+	}
+	if err := r.Client.Get(ctx, kccNetworkObjectKey, &kccNetwork); client.IgnoreNotFound(err) != nil {
+		return ctrl.Result{}, fmt.Errorf("failed fetching gcp network: %w", err)
+	}
+
+	if kccNetwork.CreationTimestamp.IsZero() {
+		logger.Info("creating GCP network")
+
+		kccNetwork = kcccomputev1beta1.ComputeNetwork{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: networkContext.Namespace,
+				Name:      kccNetworkName,
+				Annotations: map[string]string{
+					GCPProjectAnnotation: r.GCPProject,
+				},
+			},
+			Spec: kcccomputev1beta1.ComputeNetworkSpec{
+				Mtu: proto.Int64(int64(network.Spec.MTU)),
+			},
+		}
+
+		kccNetwork.Spec.AutoCreateSubnetworks = proto.Bool(false)
+
+		if err := controllerutil.SetControllerReference(&networkContext, &kccNetwork, r.Scheme); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to set controller on firewall: %w", err)
+		}
+
+		if err := r.Client.Create(ctx, &kccNetwork); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed creating gcp network: %w", err)
+		}
+	}
+
+	if !k8sconfigconnector.IsStatusConditionTrue(kccNetwork.Status.Conditions, kcccomputev1alpha1.ReadyConditionType) {
+		logger.Info("GCP network not ready yet")
+		readyCondition.Reason = "ProviderNetworkNotReady"
+		readyCondition.Message = "Network is not ready."
+		return ctrl.Result{}, nil
+	}
+
+	readyCondition.Status = metav1.ConditionTrue
+	readyCondition.Reason = "NetworkReady"
+	readyCondition.Message = "Network is ready."
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *NetworkContextReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&networkingv1alpha.NetworkContext{}).
+		Owns(&kcccomputev1beta1.ComputeNetwork{}).
+		Complete(r)
+}


### PR DESCRIPTION
This controller is responsible for creating a GCP network to represent a Datum network context via the use of the `ComputeNetwork` custom resource provided by the [GCP Config Connector](https://github.com/GoogleCloudPlatform/k8s-config-connector).

Tests have not yet been implemented, but that'll come before a merge to main.

I've included a small set of helper functions to interact with the `Conditions` fields in CRDs backed by k8s-config-connector.

> [!IMPORTANT]
> Keep in mind that this is POC quality code, and will be updated substantially before any production use case.