### PR TITLE
chore: Tweak the make run command to not expect an infra.kubeconfig file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,8 @@ build: manifests generate fmt vet ## Build manager binary.
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/main.go -health-probe-bind-address 0 \
-		--kubeconfig=$(shell pwd)/infra.kubeconfig \
-		--upstream-kubeconfig=$(shell pwd)/upstream.kubeconfig
+		--upstream-kubeconfig=$(shell pwd)/upstream.kubeconfig \
+		--infra-namespace=default
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.


### PR DESCRIPTION
This change will result in the operator determining the "infra" control plane via normal client-go detection mechanisms. In addition, the run command has been updated to specify the namespace to create KCC resources in.